### PR TITLE
Changed the rules around resolving NuGet dependencies.

### DIFF
--- a/Tql.App.Test/NuGetClientFixture.cs
+++ b/Tql.App.Test/NuGetClientFixture.cs
@@ -23,7 +23,7 @@ internal class NuGetClientFixture
     {
         using var client = CreateClient();
 
-        var packageIdentity = new PackageIdentity("Tql.Plugins.Demo", new NuGetVersion("0.1"));
+        var packageIdentity = new PackageIdentity("TQLApp.Plugins.Azure", new NuGetVersion("0.9"));
 
         var installedPackageIdentities = await client.InstallPackage(packageIdentity);
 

--- a/Tql.App.Test/Tql.App.Test.csproj
+++ b/Tql.App.Test/Tql.App.Test.csproj
@@ -3,6 +3,7 @@
 	<Import Project="..\Tql.targets" />
 
 	<ItemGroup>
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 	  <PackageReference Include="NUnit" Version="3.14.0" />
 	</ItemGroup>
 

--- a/Tql.App.Test/packages.lock.json
+++ b/Tql.App.Test/packages.lock.json
@@ -2,6 +2,16 @@
   "version": 1,
   "dependencies": {
     "net8.0-windows7.0": {
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.8.0, )",
+        "resolved": "17.8.0",
+        "contentHash": "BmTYGbD/YuDHmApIENdoyN1jCk0Rj1fJB0+B/fVekyTdVidr91IlzhqzytiUgaEAzL1ZJcYCme0MeBMYvJVzvw==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.8.0",
+          "Microsoft.TestPlatform.TestHost": "17.8.0"
+        }
+      },
       "NUnit": {
         "type": "Direct",
         "requested": "[3.14.0, )",
@@ -62,6 +72,11 @@
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "5.0.0"
         }
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.8.0",
+        "contentHash": "KC8SXWbGIdoFVdlxKk9WHccm0llm9HypcHMLUUFabRiTS3SO2fQXNZfdiF3qkEdTJhbRrxhdRxjL4jbtwPq4Ew=="
       },
       "Microsoft.CSharp": {
         "type": "Transitive",
@@ -377,6 +392,24 @@
         "type": "Transitive",
         "resolved": "1.1.0",
         "contentHash": "aOZA3BWfz9RXjpzt0sRJJMjAscAUm3Hoa4UWAfceV9UTYxgwZ1lZt5nO2myFf+/jetYQo4uTP7zS8sJY67BBxg=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.8.0",
+        "contentHash": "AYy6vlpGMfz5kOFq99L93RGbqftW/8eQTqjT9iGXW6s9MRP3UdtY8idJ8rJcjeSja8A18IhIro5YnH3uv1nz4g==",
+        "dependencies": {
+          "NuGet.Frameworks": "6.5.0",
+          "System.Reflection.Metadata": "1.6.0"
+        }
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.8.0",
+        "contentHash": "9ivcl/7SGRmOT0YYrHQGohWiT5YCpkmy/UEzldfVisLm6QxbLaK3FAJqZXI34rnRLmqqDCeMQxKINwmKwAPiDw==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.8.0",
+          "Newtonsoft.Json": "13.0.1"
+        }
       },
       "Microsoft.Web.Xdt": {
         "type": "Transitive",
@@ -735,6 +768,11 @@
           "System.Reflection": "4.3.0",
           "System.Runtime": "4.3.0"
         }
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "1.6.0",
+        "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ=="
       },
       "System.Reflection.Primitives": {
         "type": "Transitive",

--- a/Tql.App/Constants.cs
+++ b/Tql.App/Constants.cs
@@ -34,5 +34,10 @@ internal static class Constants
     );
 
     public static NuGetFramework ApplicationFrameworkVersion =
-        new(FrameworkConstants.FrameworkIdentifiers.NetCore, new Version(8, 0));
+        new(
+            FrameworkConstants.FrameworkIdentifiers.NetCoreApp,
+            new Version(8, 0),
+            FrameworkConstants.PlatformIdentifiers.Windows,
+            new Version(7, 0)
+        );
 }

--- a/Tql.App/Services/Packages/NuGet/NuGetClient.cs
+++ b/Tql.App/Services/Packages/NuGet/NuGetClient.cs
@@ -245,20 +245,15 @@ internal class NuGetClient : IDisposable
 
     public async Task<ImmutableArray<PackageIdentity>> InstallPackage(
         PackageIdentity identity,
-        DependencyBehavior dependencyBehavior = DependencyBehavior.HighestPatch,
-        bool includePrerelease = true,
-        bool allowUnlisted = false,
-        VersionConstraints versionConstraints =
-            VersionConstraints.ExactMajor | VersionConstraints.ExactMinor,
         PackageIdentity? requiredDependency = null,
         CancellationToken cancellationToken = default
     )
     {
         var resolutionContext = new ResolutionContext(
-            dependencyBehavior,
-            includePrerelease,
-            allowUnlisted,
-            versionConstraints
+            dependencyBehavior: DependencyBehavior.Lowest,
+            includePrelease: true,
+            includeUnlisted: true,
+            versionConstraints: VersionConstraints.None
         );
         var projectContext = new BlankProjectContext(NullSettings.Instance, _logger);
 


### PR DESCRIPTION
The rules in use are now closer to what NuGet uses in their examples. The original rules cause a problem while sorting dependencies. I got an exception stating that the comparer didn't return correct results. I've reviewed the new settings and I think I'm OK with them. They also prevent automatic updates, which will mean that users will get more stable versions.