### PR TITLE
Removed hack to fix main window glitches.

### DIFF
--- a/Tql.App/MainWindow.WinForms.xaml.cs
+++ b/Tql.App/MainWindow.WinForms.xaml.cs
@@ -51,7 +51,11 @@ internal partial class MainWindow
     {
         var source = PresentationSource.FromVisual(this);
         if (source == null)
+        {
+            // Delay repositioning until the source is initialized.
+            SourceInitialized += (_, _) => RepositionScreen();
             return;
+        }
 
         var showOnScreen = ShowOnScreenManager.Create(_settings.ShowOnScreen);
         var screen = showOnScreen.GetScreen();

--- a/Tql.App/MainWindow.xaml
+++ b/Tql.App/MainWindow.xaml
@@ -10,14 +10,11 @@
     xmlns:app="clr-namespace:Tql.App"
     mc:Ignorable="d"
     Title="{x:Static app:Labels.ApplicationTitle}"
-    Width="800"
+    Width="800" 
     SizeToContent="Height"
     Foreground="White"
-    Background="Transparent"
     PreviewKeyDown="Window_PreviewKeyDown"
-    Deactivated="Window_Deactivated"
-    SourceInitialized="Window_SourceInitialized"
-    Loaded="Window_Loaded">
+    Deactivated="Window_Deactivated">
     <Window.Resources>
         <Style TargetType="TextBlock">
             <Setter

--- a/Tql.App/MainWindow.xaml.cs
+++ b/Tql.App/MainWindow.xaml.cs
@@ -343,33 +343,9 @@ internal partial class MainWindow
         _search.Focus();
     }
 
-    private void Window_Loaded(object? sender, RoutedEventArgs e)
-    {
-        //
-        // HACK: Sometimes when the app starts up the first time, the content
-        // of the window isn't rendered. Resizing the window fixes this. This
-        // bug can be forced by replacing the content of this method with
-        // setting the Height to 0.
-        //
-        // This suggestion came from ChatGPT and consistently fixes the issue.
-        // This does show a slight delay in the content being rendered, on first
-        // show only. There is no impact on subsequent show calls.
-        //
-
-        Opacity = 0;
-        Dispatcher.BeginInvoke(() => Opacity = 1, DispatcherPriority.Render);
-    }
-
     private void ReloadNotifications()
     {
         _notificationBars.ItemsSource = _ui.UINotifications;
-    }
-
-    private void Window_SourceInitialized(object? sender, EventArgs e)
-    {
-        RepositionScreen();
-
-        Activate();
     }
 
     private void _searchManager_IsSearchingChanged(object? sender, EventArgs e)

--- a/Tql.App/Support/OSVersions.cs
+++ b/Tql.App/Support/OSVersions.cs
@@ -1,0 +1,7 @@
+﻿namespace Tql.App.Support;
+
+internal static class OSVersions
+{
+    public static readonly Version Windows10 = new(6, 0, 0);
+    public static readonly Version Windows10_April2018_CreatorsUpdate = new(10, 0, 17134);
+}

--- a/Tql.App/Support/WpfUtils.cs
+++ b/Tql.App/Support/WpfUtils.cs
@@ -1,63 +1,9 @@
-﻿using System.Collections.Concurrent;
-
-namespace Tql.App.Support;
+﻿namespace Tql.App.Support;
 
 internal static class WpfUtils
 {
-    private static readonly ConcurrentDictionary<
-        (double DpiScaleX, double DpiScaleY),
-        Brush
-    > BrushCache = new();
-
-    private const int NoiseTextureSize = 256;
-
     public static double PointsToPixels(int points)
     {
         return (points / 72.0) * 96.0;
-    }
-
-    public static Brush GetAcrylicBrush(Window window)
-    {
-        var dpiScale = VisualTreeHelper.GetDpi(window);
-
-        return BrushCache.GetOrAdd((dpiScale.DpiScaleX, dpiScale.DpiScaleY), CreateAcrylicBrush);
-    }
-
-    private static Brush CreateAcrylicBrush((double DpiScaleX, double DpiScaleY) dpiScale)
-    {
-        // See https://learn.microsoft.com/en-us/windows/apps/design/style/acrylic for info.
-
-        var width = (int)(NoiseTextureSize * dpiScale.DpiScaleX);
-        var height = (int)(NoiseTextureSize * dpiScale.DpiScaleY);
-
-        var pixels = new byte[width * height];
-
-        new Random().NextBytes(pixels);
-
-        var bitmap = BitmapSource.Create(
-            width,
-            height,
-            dpiScale.DpiScaleX * 96,
-            dpiScale.DpiScaleY * 96,
-            PixelFormats.Gray8,
-            null,
-            pixels,
-            width
-        );
-
-        bitmap.Freeze();
-
-        var brush = new ImageBrush
-        {
-            ImageSource = bitmap,
-            TileMode = TileMode.Tile,
-            ViewportUnits = BrushMappingMode.Absolute,
-            Viewport = new Rect(0, 0, NoiseTextureSize, NoiseTextureSize),
-            Opacity = 0.02
-        };
-
-        brush.Freeze();
-
-        return brush;
     }
 }


### PR DESCRIPTION
Enabling blur behind caused some rendering issues on first show of the window. The solution was to set AllowTransparency to true. Also removed the custom acryilc brush as Windows 10 has this as a built in option.

Closes #105.