### PR TITLE
Fixed GetBuildVersion.ps1 script.

### DIFF
--- a/scripts/GetBuildVersion.ps1
+++ b/scripts/GetBuildVersion.ps1
@@ -1,6 +1,4 @@
-param(
-  [string]$Tag
-)
+param($Tag)
 
 . "$PSScriptRoot\Include.ps1"
 
@@ -53,7 +51,7 @@ else
 
   if ($Version -eq $null)
   {
-    Write-Host "Invalid tag ref"
+    Write-Host "Invalid tag ref '$Tag'"
     exit 1
   }
 }


### PR DESCRIPTION
Requiring a script parameter to be a string makes it an empty string if the script parameter is omitted.